### PR TITLE
Ignore Proton Experimental

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,13 @@ export const SHAREDECK_REPORT_ENDPOINT =
 
 export const SHAREDECK_NEW_REPORT_URL =
 	"https://sharedeck.games/apps/${appid}/reports/new"
-export const ignoreSteam = [1887720, 1070560, 1391110, 228980]
+export const ignoreSteam = [
+  1887720, // Proton 7.0
+  1493710, // Proton Experimental
+  1070560, // Steam Linux Runtime
+  1391110, // Steam Linux Runtime - Soldier
+  228980, // Steamworks Common Redistributables
+]
 export const ignoreNonSteam = [
 	"EmulationStation-DE-x64_SteamDeck",
 	"Google Chrome",


### PR DESCRIPTION
Also adds comments documenting which ignored Steam apps correspond to which ids.

Example of "Proton Experimental" displaying in the menu without this patch:
![20230108113344_1](https://user-images.githubusercontent.com/36919/211172874-5704da02-1df9-4b9c-8a01-8d685f3f6676.jpg)

